### PR TITLE
fix(SideBar): make sidebar sticky on scroll in desktop mode

### DIFF
--- a/library/ui/src/basic-components/SideBar.tsx
+++ b/library/ui/src/basic-components/SideBar.tsx
@@ -44,13 +44,20 @@ const Css = {
         transition: "transform 0.3s ease",
         transform: isOpen ? "translateX(0)" : "translateX(-100%)",
         overflowY: "auto",
-      };
+        scrollbarWidth: "none",
+        msOverflowStyle: "none",
+      } as React.CSSProperties;
     }
 
     return {
       ...baseStyle,
-      minHeight: "100vh",
-    };
+      position: "sticky",
+      top: navbarHeight || 64,
+      height: `calc(100vh - ${navbarHeight || 64}px)`,
+      overflowY: "auto",
+      scrollbarWidth: "none",
+      msOverflowStyle: "none",
+    } as React.CSSProperties;
   },
   openIcon: (removeDefaultStyle?: boolean) => {
     if (removeDefaultStyle) return {};


### PR DESCRIPTION
## Issue
Fixes #2 

## Problem
When scrolling down the page, the sidebar completely disappears in desktop mode.

## Solution
Made the sidebar sticky by default so it stays fixed below the navbar when scrolling.

## Changes
- Added `position: sticky` for desktop mode
- Added proper `top` offset to position below navbar
- Added `height: calc(100vh - navbarHeight)` for correct sizing
- Hidden scrollbar while maintaining scroll functionality (using `scrollbarWidth: none` and `msOverflowStyle: none`)

## Testing
- Verified sidebar stays fixed when scrolling on desktop
- Verified mobile mode still works correctly
- Verified sidebar content scrolls if it overflows