### PR TITLE
[#19] Add color control prop to Number component

### DIFF
--- a/apps/demo/src/documentation/basic-components/NumberDoc.tsx
+++ b/apps/demo/src/documentation/basic-components/NumberDoc.tsx
@@ -61,6 +61,61 @@ const NumberDoc = () => {
         },
       ],
     },
+    {
+      category: t("number.examples.color"),
+      itemList: [
+        {
+          label: t("background"),
+          components: (
+            <Number
+              value={12345}
+              colorScheme="background"
+              darkMode={darkMode}
+            />
+          ),
+        },
+        {
+          label: t("tabgroup.examples.primary"),
+          components: (
+            <Number
+              value={12345}
+              colorScheme="primary"
+              darkMode={darkMode}
+            />
+          ),
+        },
+        {
+          label: t("tabgroup.examples.success"),
+          components: (
+            <Number
+              value={12345}
+              colorScheme="success"
+              darkMode={darkMode}
+            />
+          ),
+        },
+        {
+          label: t("tabgroup.examples.danger"),
+          components: (
+            <Number
+              value={12345}
+              colorScheme="danger"
+              darkMode={darkMode}
+            />
+          ),
+        },
+        {
+          label: t("muted"),
+          components: (
+            <Number
+              value={12345}
+              colorScheme="muted"
+              darkMode={darkMode}
+            />
+          ),
+        },
+      ],
+    },
   ];
   //@@viewOff:private
 

--- a/apps/demo/src/locales/cz.json
+++ b/apps/demo/src/locales/cz.json
@@ -582,13 +582,24 @@
         "description": "Volitelné inline styly (React.CSSProperties) sloučené s výchozími styly.",
         "type": "React.CSSProperties",
         "required": "false"
+      },
+      "colorScheme": {
+        "description": "Barevné schéma number (primary, success, danger, warning, info).",
+        "type": "string",
+        "required": "false"
+      },
+      "darkMode": {
+        "description": "Použije tmavé schéma barev.",
+        "type": "boolean",
+        "required": "false"
       }
     },
     "examples": {
       "basic": "Základní",
       "decimals": "S desetinnými místy",
       "tooltip": "S tooltipem",
-      "customTooltip": "S vlastním tooltipem"
+      "customTooltip": "S vlastním tooltipem",
+      "color": "S vlastní barvou"
     }
   },
   "auth": {

--- a/apps/demo/src/locales/en.json
+++ b/apps/demo/src/locales/en.json
@@ -831,13 +831,24 @@
         "description": "Optional inline styles (React.CSSProperties) merged with default styles.",
         "type": "React.CSSProperties",
         "required": "false"
+      },
+      "colorScheme": {
+        "description": "Color scheme of number (primary, success, danger, warning, info).",
+        "type": "string",
+        "required": "false"
+      },
+      "darkMode": {
+        "description": "Uses dark mode color palette.",
+        "type": "boolean",
+        "required": "false"
       }
     },
     "examples": {
       "basic": "Basic",
       "decimals": "With Decimals",
       "tooltip": "With Tooltip",
-      "customTooltip": "With Custom Tooltip"
+      "customTooltip": "With Custom Tooltip",
+      "color": "With Color Prop"
     }
   },
   "auth": {

--- a/library/ui/src/basic-components/Number.tsx
+++ b/library/ui/src/basic-components/Number.tsx
@@ -1,20 +1,26 @@
- 
 //@@viewOn:imports
 import React from "react";
+import { getColorScheme, type ColorScheme } from "../tools/colors";
 //@@viewOff:imports
-
-//@@viewOn:constants
-//@@viewOff:constants
 
 //@@viewOn:css
 const Css = {
-  span: (): React.CSSProperties => ({
-  }),
+  span: (
+    darkMode = true,
+    colorScheme?: ColorScheme,
+  ): React.CSSProperties => {
+    const scheme = getColorScheme(colorScheme ?? "background", darkMode);
+    const isNeutral =
+      colorScheme === "background" || colorScheme === "surface";
+
+    const textColor = isNeutral ? scheme.textColor : scheme.color;
+
+    return {
+      color: textColor,
+    };
+  },
 };
 //@@viewOff:css
-
-//@@viewOn:helpers
-//@@viewOff:helpers
 
 //@@viewOn:propTypes
 export type NumberProps = {
@@ -22,6 +28,8 @@ export type NumberProps = {
   tooltip?: string;
   wholeLengthNumberInTooltip?: boolean;
   minDecimalDigits?: number;
+  colorScheme?: ColorScheme;
+  darkMode?: boolean;
   style?: React.CSSProperties;
 };
 
@@ -30,6 +38,8 @@ export const NUMBER_PROP_NAMES = [
   "tooltip",
   "wholeLengthNumberInTooltip",
   "minDecimalDigits",
+  "colorScheme",
+  "darkMode",
   "style",
 ] as const;
 //@@viewOff:propTypes
@@ -39,6 +49,8 @@ export const Number: React.FC<NumberProps> = ({
   tooltip,
   wholeLengthNumberInTooltip,
   minDecimalDigits = 0,
+  colorScheme = "background",
+  darkMode = true,
   style,
 }) => {
   //@@viewOn:private
@@ -53,7 +65,10 @@ export const Number: React.FC<NumberProps> = ({
 
   //@@viewOn:render
   return (
-    <span style={{ ...Css.span(), ...style }} title={tooltipContent}>
+    <span
+      style={{ ...Css.span(darkMode, colorScheme), ...style }}
+      title={tooltipContent}
+    >
       {formattedValue}
     </span>
   );


### PR DESCRIPTION
### Description
Adds `colorScheme` and `darkMode` props to the Number component.
- Behavior consistent with Label component
- Documentation updated with examples
- Includes screenshots for demo

### Changes
- `Number.tsx`: added colorScheme + darkMode
- `NumberDoc.tsx`: added examples
- `en.json`: added translation key
- Screenshot attached

### Related Issue
#19

<img width="1892" height="907" alt="number-color-prop-usage" src="https://github.com/user-attachments/assets/98f71d17-ea7b-4038-9e73-208cde909378" />

<img width="1915" height="912" alt="number-color-props" src="https://github.com/user-attachments/assets/4c56dd0a-ad8a-4ac7-89a2-f7d340cd1580" />
