### PR TITLE
Fixed issue #23 ProfileCard expand icont render

### DIFF
--- a/library/ui/src/basic-components/ProfileCard.tsx
+++ b/library/ui/src/basic-components/ProfileCard.tsx
@@ -475,6 +475,7 @@ const ProfileCard = ({
               <p style={Css.name(removeDefaultStyle)}>{name}</p>
             )}
           </div>
+          {hasBody && (
           <button
               type="button"
               onClick={() => setIsCollapsed((prev) => !prev)}
@@ -488,6 +489,7 @@ const ProfileCard = ({
                 darkMode={darkMode}
               />
             </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Added "{hasBody &&" to the button within the ProfileCard.tsx to make it only render the chevron when there is info to show; otherwise, it is not rendered. 

<img width="933" height="421" alt="Screenshot 2026-02-11 133724" src="https://github.com/user-attachments/assets/b3e6d7f1-54b6-4d71-a739-c8bad7b2c739" />
