### PR TITLE
Update icon color logic in SideBar component

### DIFF
--- a/library/ui/src/basic-components/SideBar.tsx
+++ b/library/ui/src/basic-components/SideBar.tsx
@@ -278,6 +278,10 @@ function SideBar({
     const isHovered = hoveredKey === key;
     const scheme = getColorScheme(colorScheme, darkMode);
     const primaryScheme = getColorScheme("primary", darkMode);
+    const iconDefaultColor = getColorScheme(
+    "background",
+    darkMode,
+  ).textColor;
 
     return (
       <div key={key}>
@@ -313,7 +317,7 @@ function SideBar({
                     ? getColorScheme(item.iconColor, darkMode).color
                     : isActive
                       ? primaryScheme.color
-                      : scheme.textColor
+                      : iconDefaultColor
                 }
               />
             ) : null}


### PR DESCRIPTION
## 📝 Description

Fixed nested item icon visibility in the SideBar component for light mode.

Icons previously inherited low-contrast text color, making them hard to see. Updated the fallback icon color to use a theme-aware background contrast color so icons display correctly in both light and dark modes.

## 🔗 Related Issue

Closes #26 
