### PR TITLE
UI/UX React: TabGroup text color does not update correctly on theme change

### DIFF
--- a/library/ui/src/basic-components/documentation.tsx
+++ b/library/ui/src/basic-components/documentation.tsx
@@ -387,6 +387,7 @@ const Documentation = ({
       </Box>
       <TabGroup
         itemList={tabsList}
+        darkMode={darkMode}
         codeActive={activeTab}
         onChange={(code) => setActiveTab(code as string)}
         contentStyle={{ paddingTop: 0 }}


### PR DESCRIPTION
🐛 Issue

When switching from dark mode to light mode, the text inside the TabGroup remained styled with light-colored text, making it difficult to read in light theme.

✅ Root Cause

The darkMode prop was not being passed to the TabGroup component in the Documentation component, causing incorrect theme-based styling behavior.

🔧 Fix

Added the missing darkMode prop to the TabGroup component in the Documentation component.

Ensured the component properly reacts to theme changes.

🧪 Result

Text color now updates correctly when toggling between dark and light themes.

UI remains consistent and readable across themes.