### PR TITLE
feat(language switch): replace language switch button with new Select component

### DIFF
--- a/apps/demo/src/app/App.tsx
+++ b/apps/demo/src/app/App.tsx
@@ -3,9 +3,9 @@ import { useState, useMemo, useEffect } from "react";
 import { Helmet } from "react-helmet-async";
 import LeftMenu from "./LeftMenu";
 import Content from "./Content";
-import type { SideBarItem } from "@react-ts-ui-lib/ui";
+import type { SelectItem, SideBarItem } from "@react-ts-ui-lib/ui";
 import { getRouteList } from "./tools/RouteList";
-import { Navbar, Button, ThemeToggle, getColorScheme } from "@react-ts-ui-lib/ui";
+import { Navbar, Button, ThemeToggle, getColorScheme, Select } from "@react-ts-ui-lib/ui";
 import { useTheme } from "./context/ThemeContext";
 import { useLanguage } from "./context/LanguageContext";
 import { useTranslation } from "../i18n/useTranslation";
@@ -32,10 +32,11 @@ const Logo = ({ isMobile }: { isMobile?: boolean }) => (
     }}
   />
 );
-const LANGUAGE_MAP: Record<string, string> = {
-  en: "EN",
-  cz: "CZ",
-};
+// const LANGUAGE_MAP: Record<string, string> = {
+//   en: "EN",
+//   cz: "CZ",
+// };
+
 
 const STORAGE_KEY_DARK_MODE = "app-dark-mode";
 //@@viewOff:constants
@@ -74,6 +75,11 @@ function App() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const languageOptions: SelectItem[] = [
+    { value: "en", label: "EN" },
+    { value: "cz", label: "CZ" },
+  ];
 
   useEffect(() => {
     storage.set(STORAGE_KEY_DARK_MODE, darkMode);
@@ -118,13 +124,16 @@ function App() {
           ariaLabelDark={t("themeToggle.ariaLabelDark")}
           ariaLabelLight={t("themeToggle.ariaLabelLight")}
         />
-        <Button
-          size="sm"
-          onClick={() => setLanguage(language === "en" ? "cz" : "en")}
-          modern={true}
-        >
-          {LANGUAGE_MAP[language as keyof typeof LANGUAGE_MAP]}
-        </Button>
+        <Select
+          id="language-select"
+          name="language"
+          className={`demo-language-select ${darkMode ? "dark-mode" : "light-mode"}`}
+          itemList={languageOptions}
+          value={language}
+          onChange={(e) => setLanguage(e.target.value as "en" | "cz")}
+          darkMode={darkMode}
+          removeDefaultStyle={true}
+        />
         {user ? (
           <>
            

--- a/apps/demo/src/index.css
+++ b/apps/demo/src/index.css
@@ -17,3 +17,36 @@ h1 {
   font-size: 2.2em;
   line-height: 1.1;
 }
+
+
+/* Demo-specific styles for Select Language Switch component */
+
+select.demo-language-select {
+  padding: 0.2rem 0.75rem 0.2rem 0.5rem;
+  border-radius: 0px;
+  font-size: 1rem;
+  font-family: inherit;
+  line-height: 1.5;
+  outline: none;
+  box-shadow: none;
+  cursor: pointer;
+  transition: border 160ms, box-shadow 160ms;
+}
+
+select.demo-language-select:focus {
+  box-shadow: rgb(32, 131, 244) 0px 0px 0px 1px inset;
+}
+
+select.demo-language-select.dark-mode {
+  border: 1px solid rgb(51, 51, 51);
+  background-color: rgb(20, 20, 20);
+  color: rgb(229, 229, 229);
+}
+
+
+select.demo-language-select.light-mode {
+  border: 1px solid rgb(224, 224, 224);
+  background-color: rgb(255, 255, 255);
+  color: rgb(20, 20, 20);
+  transition: border-color 160ms, box-shadow 160ms;
+}

--- a/library/ui/src/basic-components/Select.tsx
+++ b/library/ui/src/basic-components/Select.tsx
@@ -75,6 +75,7 @@ export type SelectProps = {
   onBlur?: (e: React.FocusEvent<HTMLSelectElement>) => void;
   name?: string;
   id?: string;
+  className?: string;
 };
 
 // Const array for runtime prop extraction in Documentation
@@ -91,6 +92,7 @@ export const SELECT_PROP_NAMES = [
   "onBlur",
   "name",
   "id",
+  "className",
 ] as const;
 //@@viewOff:propTypes
 
@@ -107,6 +109,7 @@ const Select = ({
   onBlur,
   name,
   id,
+  className,
 }: SelectProps) => {
   //@@viewOn:private
   const [focused, setFocused] = useState(false);
@@ -124,6 +127,7 @@ const Select = ({
       <select
         id={id}
         name={name}
+        className={className}
         value={valueStr}
         onChange={onChange}
         onFocus={(e) => {


### PR DESCRIPTION
## Changes:

- Replaced the demo language toggle with the Select component in App.tsx
- Wired language state to the Select
- Added a custom className in the demo app and styled it via index.css
- Styling respects light/dark theme and keeps demo layout consistent

## Preview:

### Light mode select closed:
<img width="138" height="35" alt="Image" src="https://github.com/user-attachments/assets/2fc4c2f1-cd95-4d84-a665-f9ef957bd06a" />

### Light mode select open:
<img width="167" height="70" alt="Image" src="https://github.com/user-attachments/assets/7f9566c4-eb79-4f29-b3e4-0360d9971c93" />

### Dark mode select closed:
<img width="138" height="37" alt="Image" src="https://github.com/user-attachments/assets/8bf5e450-51ae-447e-b5bf-6b898c9e52db" />

### Dark mode select open:
<img width="174" height="74" alt="Image" src="https://github.com/user-attachments/assets/c9d46c25-370d-431d-948c-89a677e544e4" />

## Notes
- Closes issue #24 
- Feedback welcome - happy to adjust if needed.
