### PR TITLE
Fix: render selected SideBar item title in bold

### DIFF
--- a/library/ui/src/basic-components/SideBar.tsx
+++ b/library/ui/src/basic-components/SideBar.tsx
@@ -102,7 +102,6 @@ const Css = {
         ...baseStyle,
         backgroundColor: primaryRgba,
         color: primaryColor,
-        fontWeight: 500,
         borderLeft: `3px solid ${primaryColor}`,
         borderTopLeftRadius: 0,
         borderBottomLeftRadius: 0,


### PR DESCRIPTION
Fixes #34

Updated SideBar title styling so that the selected item text is rendered in bold while preserving theme logic.

Changes:
- Removed fontWeight from active container style
- Applied bold fontWeight only to title when isActive

This ensures clear visual distinction without affecting nested or non-selected items.
<img width="792" height="551" alt="Screenshot 2026-02-14 221313" src="https://github.com/user-attachments/assets/bb7d421d-fd3d-4699-93e0-ada6248249cd" />
<img width="1108" height="666" alt="Screenshot 2026-02-14 221320" src="https://github.com/user-attachments/assets/0188a686-5656-4007-85a8-a73bc507e9bd" />

