### PR TITLE
feat(Block): add configurable border sides

### DIFF
--- a/apps/demo/src/documentation/basic-components/BlockDoc.tsx
+++ b/apps/demo/src/documentation/basic-components/BlockDoc.tsx
@@ -47,6 +47,53 @@ const BlockDoc = () => {
         },
       ],
     },
+
+    // ✅ NEW SEPARATE CATEGORY
+    {
+      category: "Border Controls",
+      itemList: [
+        {
+          label: "Disable Top Border",
+          components: (
+            <Block
+              card="full"
+              header="No Top Border"
+              borderTop={false}
+              darkMode={darkMode}
+            >
+              <div>Top border disabled</div>
+            </Block>
+          ),
+        },
+        {
+          label: "Disable Left & Right Borders",
+          components: (
+            <Block
+              card="full"
+              header="No Side Borders"
+              borderLeft={false}
+              borderRight={false}
+              darkMode={darkMode}
+            >
+              <div>Left and right borders disabled</div>
+            </Block>
+          ),
+        },
+        {
+          label: "Default (All Borders)",
+          components: (
+            <Block
+              card="full"
+              header="Default Borders"
+              darkMode={darkMode}
+            >
+              <div>All borders enabled (default)</div>
+            </Block>
+          ),
+        },
+      ],
+    },
+
     {
       category: t("block.categories.header"),
       itemList: [

--- a/apps/demo/src/locales/cz.json
+++ b/apps/demo/src/locales/cz.json
@@ -549,6 +549,26 @@
         "description": "Použije tmavou paletu barev.",
         "type": "boolean",
         "required": "false"
+      },
+      "borderTop": {
+        "description": "Show top border.",
+        "type": "boolean",
+        "required": "false"
+      },
+      "borderRight": {
+        "description": "Show right border.",
+        "type": "boolean",
+        "required": "false"
+      },
+      "borderBottom": {
+        "description": "Show bottom border.",
+        "type": "boolean",
+        "required": "false"
+      },
+      "borderLeft": {
+        "description": "Show left border.",
+        "type": "boolean",
+        "required": "false"
       }
     },
     "categories": {

--- a/apps/demo/src/locales/en.json
+++ b/apps/demo/src/locales/en.json
@@ -789,6 +789,26 @@
         "description": "Uses dark mode color palette.",
         "type": "boolean",
         "required": "false"
+      },
+      "borderTop": {
+      "description": "Show top border.",
+      "type": "boolean",
+      "required": "false"
+      },
+      "borderRight": {
+        "description": "Show right border.",
+        "type": "boolean",
+        "required": "false"
+      },
+      "borderBottom": {
+        "description": "Show bottom border.",
+        "type": "boolean",
+        "required": "false"
+      },
+      "borderLeft": {
+        "description": "Show left border.",
+        "type": "boolean",
+        "required": "false"
       }
     },
     "categories": {

--- a/library/ui/src/basic-components/Block.tsx
+++ b/library/ui/src/basic-components/Block.tsx
@@ -29,11 +29,17 @@ const Css = {
     maxWidth?: string | number,
     cardType?: "none" | "full",
     borderColor?: string,
+    borderTop: boolean,
+    borderRight: boolean,
+    borderBottom: boolean,
+    borderLeft: boolean,
     padding?: number,
   ): React.CSSProperties => {
     if (removeDefaultStyle) {
       return {};
     }
+    
+    const borderStyle = borderColor? `1px solid ${borderColor}`: undefined;
 
     const baseStyle: React.CSSProperties = {
       backgroundColor: background,
@@ -44,7 +50,11 @@ const Css = {
       maxHeight: maxHeight,
       maxWidth: maxWidth,
       boxSizing: "border-box",
-      border: borderColor ? `1px solid ${borderColor}` : undefined,
+      borderTop: borderTop ? borderStyle : "none",
+      borderRight: borderRight ? borderStyle : "none",
+      borderBottom: borderBottom ? borderStyle : "none",
+      borderLeft: borderLeft ? borderStyle : "none",
+
       overflow: "hidden",
       marginBottom: 16,
     };
@@ -259,6 +269,11 @@ export type BlockProps = {
   hidden?: boolean;
   noPrint?: boolean;
   darkMode?: boolean;
+  borderTop?: boolean;
+  borderRight?: boolean;
+  borderBottom?: boolean;
+  borderLeft?: boolean;
+
 };
 
 // Const array for runtime prop extraction in Documentation
@@ -283,6 +298,10 @@ export const BLOCK_PROP_NAMES = [
   "hidden",
   "noPrint",
   "darkMode",
+  "borderTop",
+  "borderRight",
+  "borderBottom",
+  "borderLeft",
 ] as const;
 //@@viewOff:propTypes
 
@@ -308,6 +327,10 @@ const Block = ({
   hidden = false,
   noPrint = false,
   darkMode = true,
+  borderTop = true,
+  borderRight = true,
+  borderBottom = true,
+  borderLeft = true,
 }: BlockProps) => {
   //@@viewOn:private
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -393,6 +416,10 @@ const Block = ({
     formatUnit(maxWidth),
     card,
     borderColor,
+    borderTop,
+    borderRight,
+    borderBottom,
+    borderLeft,
     padding,
   );
 


### PR DESCRIPTION
##Fixes  #25

This PR adds four optional props to the Block component:

- borderTop
- borderRight
- borderBottom
- borderLeft

Each prop defaults to true and allows independent control of each border side.

The implementation follows the logic used in Box.tsx and keeps the existing default behavior unchanged.

Documentation and examples have been updated.




<img width="968" height="687" alt="Screenshot 2026-02-14 231502" src="https://github.com/user-attachments/assets/3cc37907-56f7-47ce-bdcc-b53653e68e15" />
<img width="1543" height="238" alt="Screenshot 2026-02-14 231524" src="https://github.com/user-attachments/assets/da555b50-2bc6-4f52-93d7-8edb3f6a595f" />

