### PR TITLE
feat: add titleAlign and subtitleAlign props to InfoGroup component

### DIFF
--- a/apps/demo/src/documentation/basic-components/InfoGroupDoc.tsx
+++ b/apps/demo/src/documentation/basic-components/InfoGroupDoc.tsx
@@ -11,6 +11,8 @@ const INFO_GROUP_EXAMPLE_CODE = `<InfoGroup
     { title: 'Name', subtitle: 'Jan' },
     { title: 'Email', subtitle: 'jan@example.com' }
   ]}
+    titleAlign="center"
+    subtitleAlign="right"
   darkMode={darkMode}
 />`;
 
@@ -190,6 +192,18 @@ const InfoGroupDoc = () => {
             <InfoGroup itemList={basicItems} removeDefaultStyle darkMode={darkMode} />
           ),
         },
+        {
+          label: "Text Alignment",
+          components: (
+            <InfoGroup
+              itemList={basicItems}
+              itemDirection="vertical"
+              titleAlign="center"
+              subtitleAlign="right"
+              darkMode={darkMode}
+            />
+          ),
+        },
       ],
     },
   ];
@@ -207,6 +221,9 @@ const InfoGroupDoc = () => {
           preview: (
             <InfoGroup
               itemList={basicItems}
+              itemDirection="vertical"
+              titleAlign ="center"
+              subtitleAlign ="right"
               darkMode={darkMode}
             />
           ),

--- a/library/ui/src/basic-components/InfoGroup.tsx
+++ b/library/ui/src/basic-components/InfoGroup.tsx
@@ -1,4 +1,5 @@
 //@@viewOn:imports
+import type { TextAlignOptions } from "../tools/textAlignOptions";
 import React from "react";
 import Icon from "./Icon";
 //@@viewOff:imports
@@ -70,6 +71,8 @@ export type InfoGroupProps = {
   hidden?: boolean;
   removeDefaultStyle?: boolean;
   darkMode?: boolean;
+  titleAlign?: TextAlignOptions;
+  subtitleAlign?: TextAlignOptions;
 };
 
 // Const array for runtime prop extraction in Documentation
@@ -83,6 +86,8 @@ export const INFO_GROUP_PROP_NAMES = [
   "hidden",
   "removeDefaultStyle",
   "darkMode",
+  "titleAlign",
+  "subtitleAlign",
 ] as const;
 //@@viewOff:propTypes
 
@@ -96,6 +101,8 @@ const InfoGroup = ({
   hidden = false,
   removeDefaultStyle = false,
   darkMode = true,
+  titleAlign = "left",
+  subtitleAlign = "left",
 }: InfoGroupProps) => {
   //@@viewOn:private
   if (hidden) return null;
@@ -121,8 +128,15 @@ const InfoGroup = ({
             <Icon icon={item.icon} size="md" darkMode={darkMode} />
           )}
           <div style={Css.itemContent()}>
-            <div>{item.title}</div>
-            {item.subtitle && <div style={{ fontSize: "0.875rem", opacity: 0.8 }}>{item.subtitle}</div>}
+            <div style = {{ textAlign : titleAlign, width : "100%"}}>
+              {item.title}
+            </div>
+
+            {item.subtitle && (
+              <div style = {{fontSize : "0.875rem", opacity : 0.8, textAlign : subtitleAlign, width: "100%",}}>
+                {item.subtitle}
+              </div>
+            )}
           </div>
         </div>
       ))}

--- a/library/ui/src/tools/textAlignOptions.ts
+++ b/library/ui/src/tools/textAlignOptions.ts
@@ -1,0 +1,1 @@
+export type TextAlignOptions = "left" | "center" | "right";


### PR DESCRIPTION
##Fixes #17

This PR adds new alignment props to the InfoGroup component to improve layout flexibility.

✨ What was added

1. Added titleAlign and subtitleAlign props

2. Supported values: "left" | "center" | "right"

3. Created a shared TextAlignOptions type in library/ui/src/tools

4. Applied alignment styling inside the component

5. Added default values (left) to maintain backward compatibility

6. Updated documentation with a new Text Alignment example


<img width="469" height="341" alt="Screenshot 2026-02-15 212939" src="https://github.com/user-attachments/assets/3f7f24e8-2805-435e-9421-76b25ff94720" />
