### PR TITLE
feat(TabGroup): add top-only borderRadius support

### DIFF
--- a/apps/demo/src/documentation/basic-components/TabGroupDoc.tsx
+++ b/apps/demo/src/documentation/basic-components/TabGroupDoc.tsx
@@ -253,6 +253,43 @@ const TabGroupDoc = () => {
         },
       ],
     },
+    {
+      category: "Border Radius (Top Corners Only)",
+      itemList: [
+        {
+          label: "Small Radius",
+          components: (
+            <TabGroup
+              itemList={basicTabs}
+              codeActive="best"
+              borderRadius="sm"
+              darkMode={darkMode}
+            />
+          ),
+        },
+        {
+          label: "Large Radius",
+          components: (
+            <TabGroup
+              itemList={basicTabs}
+              codeActive="best"
+              borderRadius="lg"
+              darkMode={darkMode}
+            />
+          ),
+        },
+        {
+          label: "Default (md)",
+          components: (
+            <TabGroup
+              itemList={basicTabs}
+              codeActive="best"
+              darkMode={darkMode}
+            />
+          ),
+        },
+      ],
+    },
   ];
   //@@viewOff:private
 

--- a/apps/demo/src/locales/en.json
+++ b/apps/demo/src/locales/en.json
@@ -1345,7 +1345,7 @@
         "description": "Whether to show a border on the left edge of the tab bar.",
         "type": "boolean",
         "required": "false"
-      },
+      },      
       "noPrint": {
         "description": "Hides the component when printing (adds no-print class).",
         "type": "boolean",
@@ -1365,6 +1365,11 @@
         "description": "Renders the component using dark mode palette.",
         "type": "boolean",
         "required": "false"
+      },
+      "borderRadius": {
+      "description": "Border radius token applied only to the top-left and top-right corners of the tab bar.",
+      "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"full\"",
+      "required": "false"
       }
     },
     "categories": {

--- a/library/ui/src/basic-components/TabGroup.tsx
+++ b/library/ui/src/basic-components/TabGroup.tsx
@@ -7,6 +7,7 @@ import {
   getBorderColor,
 } from "../tools/colors";
 import Icon from "./Icon";
+import { getRadiusValue, type RadiusToken } from "../tools/radius";
 //@@viewOff:imports
 
 //@@viewOn:constants
@@ -33,6 +34,7 @@ const Css = {
     borderRight = false,
     borderBottom = true,
     borderLeft = false,
+    borderRadiusValue?: number,
   ): React.CSSProperties => {
     if (removeDefaultStyle) {
       return {};
@@ -50,6 +52,8 @@ const Css = {
       borderRight: borderRight ? borderStyle : undefined,
       borderBottom: borderBottom ? borderStyle : undefined,
       borderLeft: borderLeft ? borderStyle : undefined,
+      borderTopLeftRadius: borderRadiusValue,
+      borderTopRightRadius: borderRadiusValue,
       gap: "1rem",
     };
   },
@@ -224,6 +228,7 @@ export type TabGroupProps = {
   hidden?: boolean;
   removeDefaultStyle?: boolean;
   darkMode?: boolean;
+  borderRadius?: RadiusToken;
 };
 
 // Const array for runtime prop extraction in Documentation
@@ -243,6 +248,7 @@ export const TAB_GROUP_PROP_NAMES = [
   "hidden",
   "removeDefaultStyle",
   "darkMode",
+  "borderRadius",
 ] as const;
 //@@viewOff:propTypes
 
@@ -262,12 +268,14 @@ const TabGroup = ({
   hidden = false,
   removeDefaultStyle = false,
   darkMode = true,
+  borderRadius = "md",
 }: TabGroupProps) => {
   //@@viewOn:private
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
   if (hidden) return null;
 
+  const borderRadiusValue = getRadiusValue(borderRadius);
   const activeItem = itemList.find((item) => item.code === codeActive);
   const activeContent = activeItem?.content || null;
 
@@ -299,6 +307,7 @@ const TabGroup = ({
             borderRight,
             borderBottom,
             borderLeft,
+            borderRadiusValue,
           )}
         >
         <div style={Css.tabsWrapper(removeDefaultStyle)}>


### PR DESCRIPTION
##Fixes #38 
Added optional borderRadius prop to TabGroup component.

- Applies border radius only to top-left and top-right corners
- Uses existing RadiusToken and getRadiusValue utility
- Works with dark and light mode
- Updated TypeScript types
<img width="1820" height="600" alt="Screenshot 2026-02-19 215444" src="https://github.com/user-attachments/assets/4d1222d2-2d69-4967-95c8-e00bca0fb175" />

- Updated documentation (prop types + examples)
- Added demo examples for sm, lg and default values

