### PR TITLE
[FEATURE] Utilities: Add custom separator support to fromCamelCase function

### DIFF
--- a/apps/demo/src/documentation/utilities/FromCamelCaseDoc.tsx
+++ b/apps/demo/src/documentation/utilities/FromCamelCaseDoc.tsx
@@ -21,10 +21,15 @@ const FromCamelCaseDoc = () => {
   const { darkMode } = useTheme();
   const { t } = useTranslation();
   const [input, setInput] = useState("helloWorld");
+  const [separator, setSeparator] = useState("");
   const [result, setResult] = useState<string>("");
 
   const handleConvert = () => {
-    setResult(fromCamelCase(input));
+    if(separator.length === 0){
+      setResult(fromCamelCase(input));
+      return;
+    }
+    setResult(fromCamelCase(input, separator));
   };
 
   const DemoComponent = (
@@ -38,6 +43,16 @@ const FromCamelCaseDoc = () => {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder={t("fromCamelCase.inputs.str.placeholder")}
+            style={inputStyle(darkMode)}
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span>{t("fromCamelCase.inputs.separator.label")}</span>
+          <input
+            type="text"
+            value={separator}
+            onChange={(e) => setSeparator(e.target.value) }
+            placeholder={t("fromCamelCase.inputs.separator.placeholder")}
             style={inputStyle(darkMode)}
           />
         </label>
@@ -58,6 +73,12 @@ const FromCamelCaseDoc = () => {
       type: t("fromCamelCase.parameters.str.type"),
       required: true,
     },
+    {
+      name: t("fromCamelCase.parameters.separator.name"),
+      description: t("fromCamelCase.parameters.separator.description"),
+      type: t("fromCamelCase.parameters.separator.type"),
+      required: false,
+    }
   ];
   const returnValueParam = {
     name: "return",
@@ -67,6 +88,7 @@ const FromCamelCaseDoc = () => {
   };
   const usageExamples = [
     { title: t("fromCamelCase.usage.basic.title"), code: t("fromCamelCase.usage.basic.code") },
+    { title: t("fromCamelCase.usage.custom.title"), code: t("fromCamelCase.usage.custom.code") },
   ];
 
   return (

--- a/apps/demo/src/locales/cz.json
+++ b/apps/demo/src/locales/cz.json
@@ -2448,11 +2448,15 @@
   },
   "fromCamelCase": {
     "title": "From Camel Case",
-    "description": "Převede řetězec v camelCase na slova oddělená mezerami (např. helloWorld → hello World).",
+    "description": "Převede řetězec ve formátu camelCase na oddělená slova. Ve výchozím nastavení jsou slova oddělena mezerami (např. helloWorld → hello World). Volitelně můžete zadat vlastní oddělovač.",
     "inputs": {
       "str": {
         "label": "camelCase řetězec",
         "placeholder": "helloWorld"
+      },
+      "separator": {
+        "label": "řetězec oddělovače (volitelné)",
+        "placeholder": "*"
       }
     },
     "actions": {
@@ -2467,6 +2471,12 @@
         "description": "camelCase řetězec k převodu.",
         "type": "string",
         "required": "true"
+      },
+      "separator": {
+        "name": "oddělovač",
+        "description": "Volitelný řetězec používaný k oddělení slov.",
+        "type": "string",
+        "required": "false"
       }
     },
     "returnValue": {
@@ -2477,6 +2487,10 @@
       "basic": {
         "title": "Základní použití",
         "code": "import { fromCamelCase } from \"@react-ts-ui-lib/utilities\";\n\nconst text = fromCamelCase(\"helloWorld\");\n// \"hello World\""
+      },
+      "custom": {
+        "title": "S vlastním oddělovačem",
+        "code": "import { fromCamelCase } from \"@react-ts-ui-lib/utilities\";\n\nconst text = fromCamelCase(\"helloWorld\", \"-\");\n// \"hello-World\""
       }
     }
   },

--- a/apps/demo/src/locales/en.json
+++ b/apps/demo/src/locales/en.json
@@ -2448,11 +2448,15 @@
   },
   "fromCamelCase": {
     "title": "From Camel Case",
-    "description": "Converts a camelCase string to space-separated words (e.g. helloWorld → hello World).",
+    "description": "Converts a camelCase string to separated words. By default, words are separated by spaces (e.g. helloWorld → hello World). You can optionally provide a custom separator.",
     "inputs": {
       "str": {
         "label": "camelCase string",
         "placeholder": "helloWorld"
+      },
+      "separator": {
+        "label": "separator string (optional)",
+        "placeholder": "*"
       }
     },
     "actions": {
@@ -2467,6 +2471,12 @@
         "description": "camelCase string to convert.",
         "type": "string",
         "required": "true"
+      },
+      "separator": {
+        "name": "separator",
+        "description": "Optional string used to separate words.",
+        "type": "string",
+        "required": "false"
       }
     },
     "returnValue": {
@@ -2477,6 +2487,10 @@
       "basic": {
         "title": "Basic usage",
         "code": "import { fromCamelCase } from \"@react-ts-ui-lib/utilities\";\n\nconst text = fromCamelCase(\"helloWorld\");\n// \"hello World\""
+      },
+      "custom": {
+        "title": "With Custom Separator",
+        "code": "import { fromCamelCase } from \"@react-ts-ui-lib/utilities\";\n\nconst text = fromCamelCase(\"helloWorld\", \"-\");\n// \"hello-World\""
       }
     }
   },

--- a/library/utilities/fromCamelCase.ts
+++ b/library/utilities/fromCamelCase.ts
@@ -1,10 +1,12 @@
 /**
  * Converts a camelCase string to space-separated words.
  * Inserts a space before each uppercase letter that follows a lowercase letter.
+ * By default, words are separated by spaces, but you can optionally provide a custom separator.
  * @param str - camelCase string (e.g. "helloWorld")
- * @returns string with words separated by spaces (e.g. "hello World")
+ * @param separator - Optional string used to separate words (default is a space).
+ * @returns string with words separated by the space or specified separator (e.g. "hello World" or "hello-World")
  */
-export const fromCamelCase = (str: string): string => {
+export const fromCamelCase = (str: string, separator: string = " "): string => {
   if (typeof str !== "string") return "";
-  return str.replace(/([a-z])([A-Z])/g, "$1 $2").trim();
+  return str.replace(/([a-z])([A-Z])/g, (_, p1, p2) => `${p1}${separator}${p2}`).trim();
 };


### PR DESCRIPTION
## Short description of the fix

This PR enhances the fromCamelCase utility by adding support for a custom separator parameter.

Previously, the function relied on a predefined separator (e.g., space), which limited flexibility across different formatting use cases. With this update, fromCamelCase now accepts an optional second argument:

separator?: string

If provided, the function will use the custom separator when transforming camelCase strings. If omitted, it defaults to a space to maintain backward compatibility.

## example

fromCamelCase("helloWorld", "-") // "hello-world"
fromCamelCase("helloWorld", "_") // "hello_world"
fromCamelCase("helloWorld")      // "hello World"

## Issue to close

[https://github.com/Karel-cz/react-ts-ui-lib/issues/36](url)

---

- [✔️ ] Synced repo before changes
- [✔️ ] Documentation updated
- [✔️ ] Functionality verified locally
