### PR TITLE
Fix/label dark mode support in input component

### DIFF
--- a/apps/demo/src/documentation/basic-components/InputDoc.tsx
+++ b/apps/demo/src/documentation/basic-components/InputDoc.tsx
@@ -23,6 +23,7 @@ const INPUT_EXAMPLE_CODE = `<Input
   label="Email"
   value={value}
   onChange={(e) => setValue(e.target.value)}
+  darkMode={true}
 />`;
 
 const InputDoc = () => {
@@ -47,6 +48,7 @@ const InputDoc = () => {
               placeholder="Type something..."
               value={basicValue}
               onChange={(e) => setBasicValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -62,6 +64,7 @@ const InputDoc = () => {
               placeholder="Search..."
               value={basicValue}
               onChange={(e) => setBasicValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -78,6 +81,7 @@ const InputDoc = () => {
               placeholder="Enter your name"
               value={basicValue}
               onChange={(e) => setBasicValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -95,6 +99,7 @@ const InputDoc = () => {
               required
               value={requiredValue}
               onChange={(e) => setRequiredValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -111,6 +116,7 @@ const InputDoc = () => {
               disabled
               value={disabledValue}
               onChange={(e) => setDisabledValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -127,6 +133,7 @@ const InputDoc = () => {
               placeholder="No default styling"
               value={basicValue}
               onChange={(e) => setBasicValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -143,6 +150,7 @@ const InputDoc = () => {
               borderRadius="xs"
               value={basicValue}
               onChange={(e) => setBasicValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -154,6 +162,7 @@ const InputDoc = () => {
               borderRadius="sm"
               value={basicValue}
               onChange={(e) => setBasicValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -165,6 +174,7 @@ const InputDoc = () => {
               borderRadius="md"
               value={basicValue}
               onChange={(e) => setBasicValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -176,6 +186,7 @@ const InputDoc = () => {
               borderRadius="lg"
               value={basicValue}
               onChange={(e) => setBasicValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -187,6 +198,7 @@ const InputDoc = () => {
               borderRadius="full"
               value={basicValue}
               onChange={(e) => setBasicValue(e.target.value)}
+              darkMode={darkMode}
             />
           ),
         },
@@ -213,6 +225,7 @@ const InputDoc = () => {
               label="Email"
               value="example@mail.com"
               onChange={() => {}}
+              darkMode={darkMode}
             />
           ),
         }}

--- a/apps/demo/src/locales/en.json
+++ b/apps/demo/src/locales/en.json
@@ -1112,6 +1112,11 @@
         "type": "string",
         "required": "false"
       },
+      "darkMode": {
+        "description": "Renders the component using dark mode palette.",
+        "type": "boolean",
+        "required": "false"
+      },
       "onChange": {
         "description": "Called when the input value changes.",
         "type": "function",

--- a/library/ui/src/basic-components/Input.tsx
+++ b/library/ui/src/basic-components/Input.tsx
@@ -1,6 +1,7 @@
 //!#Imports: start
 import React from "react";
 import { getRadiusValue, type RadiusToken } from "../tools/radius";
+import { getColorScheme } from "../tools/colors";
 //!#Imports: end
 
 //!#Constants: start
@@ -13,11 +14,15 @@ const Css = {
     flexDirection: "column",
     gap: "0.5rem",
   }),
-  label: (): React.CSSProperties => ({
-    fontSize: "0.875rem",
-    fontWeight: 600,
-    color: "#333",
-  }),
+  label: (darkMode: boolean): React.CSSProperties => {
+    const scheme = getColorScheme("background", darkMode);
+
+    return {
+      fontSize: "0.875rem",
+      fontWeight: 600,
+      color: scheme.textColor,
+    };
+  },
   input: (removeDefaultStyle?: boolean, borderRadiusValue?: number): React.CSSProperties => {
     if (removeDefaultStyle) {
       return {};
@@ -57,6 +62,7 @@ export type InputProps = {
   id?: string;
   name?: string;
   borderRadius?: RadiusToken;
+  darkMode:boolean,
 };
 
 export const INPUT_PROP_NAMES = [
@@ -66,6 +72,7 @@ export const INPUT_PROP_NAMES = [
   "value",
   "required",
   "label",
+  "darkMode",
   "onChange",
   "onBlur",
   "onFocus",
@@ -90,6 +97,7 @@ const Input: React.FC<InputProps> = ({
   id,
   name,
   borderRadius = "md",
+  darkMode = true,
 }) => {
   //!#visualComponent: start
   const borderRadiusValue = getRadiusValue(borderRadius);
@@ -97,8 +105,7 @@ const Input: React.FC<InputProps> = ({
   return (
     <div style={{ ...Css.wrapper(), ...style }}>
       {label && (
-        <label htmlFor={id} style={Css.label()}>
-          {label}
+        <label htmlFor={id} style={Css.label(darkMode)}>{label}
           {required && <span style={{ color: "#d32f2f" }}> *</span>}
         </label>
       )}


### PR DESCRIPTION
## Short description of the fix
Fix label dark mode support in Input component

<!-- Briefly describe what this PR changes and why. -->
Update the Input component to properly support dark mode for the label.

The implementation should:

Remove any hardcoded color values
Use theme-based styling consistent with other components (e.g., Block)
Ensure the label is clearly visible in both light and dark modes
Maintain consistency with the design system

## Screenshot of the fix
<img width="593" height="159" alt="Screenshot 2026-03-23 at 8 43 48 AM" src="https://github.com/user-attachments/assets/edf7daea-f87a-480e-9d0c-768bdcf31c36" />
<img width="592" height="183" alt="Screenshot 2026-03-23 at 8 44 13 AM" src="https://github.com/user-attachments/assets/60bdbb6d-4bee-42c6-9d86-471f52ebc5cf" />

<!-- Add a screenshot or screen recording if the change is visible in the UI. -->

## Issue to close

Closes #94 

---

- [X] Synced repo before changes?
- [X] Documentation updated (if needed)?
- [X] Functionality verified locally?
