### PR TITLE
Feature Added fixDecimalDigits prop to Number

### DIFF
--- a/apps/demo/src/locales/en.json
+++ b/apps/demo/src/locales/en.json
@@ -1056,6 +1056,11 @@
         "description": "Uses dark mode color palette.",
         "type": "boolean",
         "required": "false"
+      },
+      "fixDecimalDigits": {
+        "description": "Forces the number to be displayed with an exact number of decimal places.",
+        "type": "number",
+        "required": "false"
       }
     },
     "examples": {

--- a/library/ui/src/basic-components/Number.tsx
+++ b/library/ui/src/basic-components/Number.tsx
@@ -38,6 +38,7 @@ export type NumberProps = {
   colorScheme?: ColorScheme;
   darkMode?: boolean;
   style?: React.CSSProperties;
+  fixDecimalDigits?:number;
 };
 
 export const NUMBER_PROP_NAMES = [
@@ -49,6 +50,7 @@ export const NUMBER_PROP_NAMES = [
   "colorScheme",
   "darkMode",
   "style",
+  "fixDecimalDigits"
 ] as const;
 //!#propTypes: end
 
@@ -61,11 +63,18 @@ const Number: React.FC<NumberProps> = ({
   colorScheme = "background",
   darkMode = true,
   style,
+  fixDecimalDigits
 }) => {
   //!#visualComponent: start
   const formattedValue = new Intl.NumberFormat(undefined, {
-    minimumFractionDigits: minDecimalDigits,
-    maximumFractionDigits: maxDecimalDigits ?? Math.max(minDecimalDigits, 20),
+    minimumFractionDigits:
+      fixDecimalDigits !== undefined ? fixDecimalDigits : minDecimalDigits,
+
+
+    maximumFractionDigits:
+      fixDecimalDigits !== undefined
+        ? fixDecimalDigits
+        : maxDecimalDigits ?? Math.max(minDecimalDigits, 20),
   }).format(value);
 
   const tooltipContent =


### PR DESCRIPTION
## Short description of the fix
Added fixDecimalDigits prop to Number component

<!-- Briefly describe what this PR changes and why. -->
When fixDecimalDigits is provided:

The number is always rendered with the exact number of decimal places
Missing decimal digits are padded with zeros
Existing decimals are rounded or adjusted accordingly
Default behavior remains unchanged when the prop is not provided

## Screenshot of the fix
<img width="414" height="172" alt="Screenshot 2026-03-24 at 7 19 49 PM" src="https://github.com/user-attachments/assets/9cf4cac4-f1e4-4ad8-b572-7f3437803977" />


<!-- Add a screenshot or screen recording if the change is visible in the UI. -->

## Issue to close
<img width="503" height="96" alt="Screenshot 2026-03-24 at 7 19 59 PM" src="https://github.com/user-attachments/assets/9b5392bb-5934-41a3-a56c-21d2f7cc9a38" />

 Closes #92 

---

- [X] Synced repo before changes?
- [X] Documentation updated (if needed)?
- [X] Functionality verified locally?
