### PR TITLE
Added zIndex prop to Popover component

### DIFF
--- a/apps/demo/src/locales/en.json
+++ b/apps/demo/src/locales/en.json
@@ -2338,6 +2338,11 @@
         "description": "Predefined border radius token (none, xs, sm, md, lg, full) or a custom number (px).",
         "type": "string | number",
         "required": "false"
+      },
+      "zIndex": {
+        "description": "Controls the stacking order of the Popover. Higher values will render the popover above other elements.",
+        "type": "number",
+        "required": "false"
       }
     },
     "categories": {

--- a/library/ui/src/basic-components/Popover.tsx
+++ b/library/ui/src/basic-components/Popover.tsx
@@ -11,11 +11,11 @@ const GAP = 8;
 
 //!#Styles: start
 const Css = {
-  panelPosition: (position: { top: number; left: number }): React.CSSProperties => ({
+  panelPosition: (position: { top: number; left: number; zIndex:number }): React.CSSProperties => ({
     position: "fixed",
     top: position.top,
     left: position.left,
-    zIndex: 9999,
+    zIndex: position.zIndex,
   }),
 
   panelStyle: (removeDefaultStyle?: boolean, darkMode = true, borderRadiusValue = 8): React.CSSProperties => {
@@ -63,6 +63,7 @@ export type PopoverProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   borderRadius?: RadiusToken | number;
+  zIndex?:number;
 };
 
 // Const array for runtime prop extraction in Documentation
@@ -77,6 +78,7 @@ export const POPOVER_PROP_NAMES = [
   "open",
   "onOpenChange",
   "borderRadius",
+  "zIndex"
 ] as const;
 //!#propTypes: end
 
@@ -91,9 +93,10 @@ const Popover = ({
   open,
   onOpenChange,
   borderRadius = "md",
+  zIndex=1000
 }: PopoverProps) => {
   //!#visualComponent: start
-  const [panelPosition, setPanelPosition] = useState<{ top: number; left: number } | undefined>(undefined);
+  const [panelPosition, setPanelPosition] = useState<{ top: number; left: number; zIndex:number } | undefined>(undefined);
   const panelRef = useRef<HTMLDivElement>(null);
 
   const updatePosition = useCallback(() => {
@@ -102,21 +105,22 @@ const Popover = ({
       setPanelPosition({
         top: rect.bottom + GAP,
         left: rect.left,
+        zIndex:zIndex,
       });
     } else {
       setPanelPosition(undefined);
     }
-  }, [triggerRef]);
+  }, [triggerRef,zIndex]);
 
   useLayoutEffect(() => {
     if (!open || content == null) return;
     const rect = triggerRef?.current?.getBoundingClientRect();
     if (rect) {
-      const position = { top: rect.bottom + GAP, left: rect.left };
+      const position = { top: rect.bottom + GAP, left: rect.left, zIndex:zIndex };
       const id = requestAnimationFrame(() => setPanelPosition(position));
       return () => cancelAnimationFrame(id);
     }
-  }, [open, content, triggerRef]);
+  }, [open, content, triggerRef, zIndex]);
 
   useEffect(() => {
     if (!open) return;


### PR DESCRIPTION
## Short description of the fix
Add zIndex prop to Popover component

<!-- Briefly describe what this PR changes and why. -->
When zIndex is provided:

The value is passed to the component’s CSS
It controls the stacking order of the popover
Allows users to override default layering behavior

## Screenshot of the fix
<img width="503" height="294" alt="Screenshot 2026-03-24 at 7 26 34 PM" src="https://github.com/user-attachments/assets/63c5cc14-f81e-4fce-ad95-8454d8276d5d" />

<!-- Add a screenshot or screen recording if the change is visible in the UI. -->

## Issue to close

Closes #93

---

- [X] Synced repo before changes?
- [X] Documentation updated (if needed)?
- [X] Functionality verified locally?
