### PR TITLE
feat: added preesed functionality to button

### DIFF
--- a/library/ui/src/basic-components/Button.tsx
+++ b/library/ui/src/basic-components/Button.tsx
@@ -35,6 +35,7 @@ const Css = {
     modernHoverBackground?: string,
     shadow?: string,
     hoverShadow?: string,
+    pressed?: boolean
   ): React.CSSProperties => {
     if (removeDefaultStyle) {
       return {};
@@ -59,14 +60,30 @@ const Css = {
       backgroundSize: useModern ? "200% 200%" : undefined,
       backgroundPosition: useModern ? (hover ? "100% 0%" : "0% 50%") : undefined,
       color: textColor,
-      cursor: isDisabled ? "not-allowed" : "pointer",
+      cursor: isDisabled ? "default" : "pointer",
       fontWeight: 600,
       fontSize: fontSize,
       height: height,
       width: width,
       transition:
         "background-position 260ms ease, background 160ms ease, color 160ms ease, box-shadow 180ms ease",
-      boxShadow: useModern ? (hover ? hoverShadow : shadow) : undefined,
+      //boxShadow: useModern ? (hover ? hoverShadow : shadow) : undefined,
+      boxShadow: pressed
+  ? "inset 0 2px 6px rgba(0,0,0,0.4)"
+  : useModern
+    ? (hover ? hoverShadow : shadow)
+    : undefined,
+      transform: pressed
+  ? "scale(0.96)"
+  : isDisabled
+    ? "scale(0.98)"
+    : undefined,
+
+opacity: pressed
+  ? 0.95
+  : isDisabled
+    ? 0.85
+    : 1,
       outline: "none",
       WebkitTapHighlightColor: "transparent",
       position: "relative",
@@ -116,6 +133,7 @@ export type ButtonProps = {
   modern?: boolean;
   hidden?: boolean;
   width?: string;
+  pressed?: boolean;
 };
 
 // Const array for runtime prop extraction in Documentation
@@ -140,7 +158,8 @@ export const BUTTON_PROP_NAMES = [
   "noPrint",
   "modern",
   "hidden",
-  "width"
+  "width",
+  "pressed"
 ] as const;
 //!#propTypes: end
 
@@ -164,7 +183,8 @@ const Button = ({
   noPrint = false,
   modern = false,
   hidden = false,
-  width
+  width,
+  pressed = false
 }: ButtonProps) => {
   //!#visualComponent: start
   const [hover, setHover] = useState(false);
@@ -174,9 +194,24 @@ const Button = ({
   const disabledBg = getColorScheme("surface", darkMode).color;
   const disabledText = getColorScheme("muted", darkMode).color;
 
-  const isDisabled = disabled || isPending;
-  const background = isDisabled ? disabledBg : scheme.color;
-  const textColor = isDisabled ? disabledText : scheme.textColor;
+  const isDisabled = disabled || isPending || pressed;
+  //const background = isDisabled ? disabledBg : scheme.color;
+  //const textColor = isDisabled ? disabledText : scheme.textColor;
+  const pressedBg = getColorScheme("primaryDark", darkMode).color;
+const pressedText = scheme.textColor;
+
+const background = pressed
+  ? pressedBg
+  : isDisabled
+    ? disabledBg
+    : scheme.color;
+
+const textColor = pressed
+  ? pressedText
+  : isDisabled
+    ? disabledText
+    : scheme.textColor;
+
   const borderRadiusValue = getRadiusValue(borderRadius);
 
   const buttonSize = getButtonSize(size);
@@ -208,6 +243,7 @@ const Button = ({
 
   const content = children || label;
   const useModernGradient = modern && significance !== "distinct";
+
   //!#render components: start
   const buttonStyle = Css.button(
     removeDefaultStyle,
@@ -245,7 +281,7 @@ const Button = ({
       aria-busy={isPending || undefined}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
-      onClick={onClick}
+      onClick={pressed ? undefined : onClick}
     >
       <span style={Css.content(isPending)}>
         {iconPosition === "left" && (


### PR DESCRIPTION
## Short description of the fix

Added support for a new optional `pressed` prop in the Button component.

When 'pressed' is true:
1. Button renders in a visually distinct pressed state
2. clicks are ignored
3. Cursor changes to default
4. Hover effects are disabled

Also added visual feedback using scale, opacity, inset shadow to clearly distinguish the pressed state from disabled.

## Screenshot of the fix

<!-- Add a screenshot or screen recording if the change is visible in the UI. -->
<img width="1887" height="908" alt="Screenshot (51)" src="https://github.com/user-attachments/assets/2bcc34d3-d254-4994-90b0-1ef17bcb9cee" />


## Issue to close

<!-- e.g. Closes #123 -->
Closes #75
---

- [x] Synced repo before changes?
- [x] Documentation updated (if needed)?
- [x] Functionality verified locally?
